### PR TITLE
Fixed Runtime Assert in BeginPlay After Loading Model in UE 5.2

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeAssetActor.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAssetActor.cpp
@@ -29,7 +29,7 @@ AglTFRuntimeAssetActor::AglTFRuntimeAssetActor()
 // Called when the game starts or when spawned
 void AglTFRuntimeAssetActor::LoadAsset()
 {
-	Super::BeginPlay();
+	Super::DispatchBeginPlay();
 
 	if (!Asset)
 	{


### PR DESCRIPTION
Error occurs on play immediately after the first object is spawned. Tested on forge branch `feat/5.2-compile` on the test waterline map.

The new function `DispatchBeginPlay()` does some additional initialization logic that is required prior to calling `BeginPlay()`

![image](https://github.com/bifrostai/glTFRuntime/assets/112605666/8c7db325-14b4-4b68-abe9-f3ac0d7b7931)
