### PR TITLE
Fix UE5.2 compile errors

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserSkeletalMeshes.cpp
@@ -1975,12 +1975,19 @@ UAnimSequence* FglTFRuntimeParser::LoadSkeletalAnimation(USkeletalMesh * Skeleta
 	}
 
 #if WITH_EDITOR
-#if ENGINE_MAJOR_VERSION > 4
+	#if ENGINE_MAJOR_VERSION >= 5
+		#if ENGINE_MINOR_VERSION >= 2
+	AnimSequence->GetController().SetFrameRate(FrameRate, false);
+	AnimSequence->GetController().SetNumberOfFrames(NumFrames);
+	AnimSequence->GetController().NotifyPopulated();
+	AnimSequence->GetController().CloseBracket(false);
+		#else
 	// hack for calling GenerateTransientData()
 	AnimSequence->GetDataModel()->PostDuplicate(false);
-#else
+		#endif
+	#else
 	AnimSequence->PostProcessSequence();
-#endif
+	#endif
 #else
 	AnimSequence->CompressedData.CompressedDataStructure = MakeUnique<FUECompressedAnimData>();
 #if ENGINE_MAJOR_VERSION > 4
@@ -2161,12 +2168,19 @@ UAnimSequence* FglTFRuntimeParser::CreateAnimationFromPose(USkeletalMesh * Skele
 	}
 
 #if WITH_EDITOR
-#if ENGINE_MAJOR_VERSION > 4
+	#if ENGINE_MAJOR_VERSION >= 5
+		#if ENGINE_MINOR_VERSION >= 2
+			AnimSequence->GetController().SetFrameRate(FrameRate, false);
+			AnimSequence->GetController().SetNumberOfFrames(NumFrames);
+			AnimSequence->GetController().NotifyPopulated();
+			AnimSequence->GetController().CloseBracket(false);
+		#else
 	// hack for calling GenerateTransientData()
 	AnimSequence->GetDataModel()->PostDuplicate(false);
-#else
-	AnimSequence->PostProcessSequence();
-#endif
+		#endif
+	#else
+		AnimSequence->PostProcessSequence();
+	#endif
 #else
 	AnimSequence->CompressedData.CompressedDataStructure = MakeUnique<FUECompressedAnimData>();
 #if ENGINE_MAJOR_VERSION > 4
@@ -2351,12 +2365,19 @@ UAnimSequence* FglTFRuntimeParser::CreateSkeletalAnimationFromPath(USkeletalMesh
 	}
 
 #if WITH_EDITOR
-#if ENGINE_MAJOR_VERSION > 4
+	#if ENGINE_MAJOR_VERSION >= 5
+		#if ENGINE_MINOR_VERSION >= 2
+	AnimSequence->GetController().SetFrameRate(FrameRate, false);
+	AnimSequence->GetController().SetNumberOfFrames(NumFrames);
+	AnimSequence->GetController().NotifyPopulated();
+	AnimSequence->GetController().CloseBracket(false);
+		#else
 	// hack for calling GenerateTransientData()
 	AnimSequence->GetDataModel()->PostDuplicate(false);
-#else
+		#endif
+	#else
 	AnimSequence->PostProcessSequence();
-#endif
+	#endif
 #else
 	UglTFAnimBoneCompressionCodec* CompressionCodec = NewObject<UglTFAnimBoneCompressionCodec>();
 	AnimSequence->CompressedData.CompressedDataStructure = MakeUnique<FUECompressedAnimData>();

--- a/Source/glTFRuntime/Public/glTFRuntimeSoundWave.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeSoundWave.h
@@ -27,6 +27,11 @@ public:
 		RuntimeAudioOffset = 0;
 	}
 
+	TUniquePtr<Audio::IProxyData> CreateNewProxyData(const Audio::FProxyDataInitParams& InitParams)
+	{
+		return nullptr;
+	}
+
 protected:
 	TArray64<uint8> RuntimeAudioData;
 	int64 RuntimeAudioOffset;


### PR DESCRIPTION
In preparation to merge the 5.1 branch into 5.2 branch, certain errors were encountered. The following changes were made to fix these errors:

Updated directives in `gltFRuntimeParserSkeletalMeshes ` to match that from the master branch to account for version 5.2, removing the error that `PostDuplicate()` is not a member function of `GetDataModel()`

Defined a null function for `CreateNewProxyData()` in gltFRuntimeSoundWave that was missing a definition, this function was a pure virtual function declared in the `IAudioProxyDataFactory `class that was inherited by gltFRuntimeSoundWave class. 