### PR TITLE
Expose Animation Data

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeAnimationCurve.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAnimationCurve.cpp
@@ -140,3 +140,23 @@ void UglTFRuntimeAnimationCurve::AddScaleValue(const float InTime, const FVector
 	FKeyHandle ScaleKey2 = ScaleCurves[2].AddKey(InTime, InScale.Z);
 	ScaleCurves[2].SetKeyInterpMode(ScaleKey2, InterpolationMode);
 }
+
+
+const FRichCurve UglTFRuntimeAnimationCurve::GetRotationCurves(int32 index) {
+	if (index >= 3) {
+		return FRichCurve();
+	}
+	return RotationCurves[index];
+}
+const FRichCurve UglTFRuntimeAnimationCurve::GetLocationCurves(int32 index) {
+	if (index >= 3) {
+		return FRichCurve();
+	}
+	return LocationCurves[index];
+}
+const FRichCurve UglTFRuntimeAnimationCurve::GetScaleCurves(int32 index) {
+	if (index >= 3) {
+		return FRichCurve();
+	}
+	return ScaleCurves[index];
+}

--- a/Source/glTFRuntime/Private/glTFRuntimeAssetActor.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeAssetActor.cpp
@@ -411,10 +411,18 @@ void AglTFRuntimeAssetActor::Tick(float DeltaTime)
 			FTransform FrameTransform = Pair.Value->GetTransformValue(CurveBasedAnimationsTimeTracker[Pair.Key]);
 			Pair.Key->SetRelativeTransform(FrameTransform);
 		}
-		CurveBasedAnimationsTimeTracker[Pair.Key] += DeltaTime;
+		//CurveBasedAnimationsTimeTracker[Pair.Key] += DeltaTime;
 	}
 }
 
 void AglTFRuntimeAssetActor::ReceiveOnStaticMeshComponentCreated_Implementation(UStaticMeshComponent* StaticMeshComponent, const FglTFRuntimeNode& Node) {}
 
 void AglTFRuntimeAssetActor::ReceiveOnSkeletalMeshComponentCreated_Implementation(USkeletalMeshComponent* SkeletalMeshComponent, const FglTFRuntimeNode& Node) {}
+
+void AglTFRuntimeAssetActor::SetCurveAnimationTimeTracker(USceneComponent* comp, const float& Time) {
+	CurveBasedAnimationsTimeTracker[comp] = Time;
+}
+
+const TArray<FString> AglTFRuntimeAssetActor::GetAnimationNames() {
+	return DiscoveredCurveAnimationsNames.Array();
+}

--- a/Source/glTFRuntime/Public/glTFRuntimeAnimationCurve.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeAnimationCurve.h
@@ -54,4 +54,8 @@ public:
     void AddRotationValue(const float InTime, const FVector InEulerRotation, const ERichCurveInterpMode InterpolationMode);
     void AddScaleValue(const float InTime, const FVector InScale, const ERichCurveInterpMode InterpolationMode);
     void SetDefaultValues(const FVector Location, const FVector EulerRotation, const FVector Scale);
+
+	const FRichCurve GetRotationCurves(int32 index);
+	const FRichCurve GetLocationCurves(int32 index);
+	const FRichCurve GetScaleCurves(int32 index);
 };

--- a/Source/glTFRuntime/Public/glTFRuntimeAssetActor.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeAssetActor.h
@@ -69,6 +69,12 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "glTFRuntime")
 	void SetCurveAnimationByName(const FString& CurveAnimationName);
 
+	UFUNCTION(BlueprintCallable, Category = "glTFRuntime")
+	void SetCurveAnimationTimeTracker(USceneComponent* comp, const float& Time);
+
+	UFUNCTION(BlueprintCallable, Category = "glTFRuntime")
+	const TArray<FString> GetAnimationNames();
+
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Meta = (ExposeOnSpawn = true), Category = "glTFRuntime")
 	bool bAllowNodeAnimations;
 


### PR DESCRIPTION
Cherry picked commit 22a8d91 from 5.1.0 branch to support animation frame randomization feature in UE5.2

Exposed gltf animation data, Animation Name lists and the animation curve through getters.

Exposed data used to drive animation variation feature.

