### PR TITLE
fix: mishandling of two sided translucent material

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -64,7 +64,7 @@ UMaterialInterface* FglTFRuntimeParser::LoadMaterial_Internal(const int32 Index,
 	{
 		RuntimeMaterial.MaterialType = EglTFRuntimeMaterialType::TwoSidedTranslucent;
 	}
-	if (RuntimeMaterial.bMasked && RuntimeMaterial.bTwoSided)
+	else if (RuntimeMaterial.bMasked && RuntimeMaterial.bTwoSided)
 	{
 		RuntimeMaterial.MaterialType = EglTFRuntimeMaterialType::TwoSidedMasked;
 	}


### PR DESCRIPTION
The missing `else` in the if-else clauses for determining the material type causes all translucent materials to use the "translucent" material, regardless of whether it's two-sided or not. Instead, we should use either "translucent" or "translucent + two-sided".