### PR TITLE
unreal: fix log spam from streaming hack

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -399,8 +399,13 @@ UTexture2D* FglTFRuntimeParser::BuildTexture(UObject* Outer, const TArray<FglTFR
 #endif
 
 #if !WITH_EDITOR
-		// this is a hack for allowing texture streaming without messing around with deriveddata
-		Mip->BulkData.SetBulkDataFlags(BULKDATA_PayloadInSeperateFile);
+		// Mark bulk data as not inline to allow streaming (makes IsInlined() return false)
+		// This is a better HACK than the previous one using IsSeparateFile() which causes
+		// a lot of spam in TextureDerivedData.cpp (Loading non-streamed mips from an external bulk file)
+		if (ImagesConfig.bStreaming)
+		{
+			Mip->BulkData.SetBulkDataFlags(BULKDATA_PayloadAtEndOfFile);
+		}
 #endif
 		Mip->BulkData.Lock(LOCK_READ_WRITE);
 
@@ -514,8 +519,13 @@ UVolumeTexture* FglTFRuntimeParser::BuildVolumeTexture(UObject* Outer, const TAr
 #endif
 
 #if !WITH_EDITOR
-		// this is a hack for allowing texture streaming without messing around with deriveddata
-		Mip->BulkData.SetBulkDataFlags(BULKDATA_PayloadInSeperateFile);
+		// Mark bulk data as not inline to allow streaming (makes IsInlined() return false)
+		// This is a better HACK than the previous one using IsSeparateFile() which causes
+		// a lot of spam in TextureDerivedData.cpp (Loading non-streamed mips from an external bulk file)
+		if (ImagesConfig.bStreaming)
+		{
+			Mip->BulkData.SetBulkDataFlags(BULKDATA_PayloadAtEndOfFile);
+		}
 #endif
 		Mip->BulkData.Lock(LOCK_READ_WRITE);
 


### PR DESCRIPTION
Change the streaming MIPs to use BULKDATA_PayloadAtEndOfFile instead of BULKDATA_PayloadInSeperateFile as markers. According to the comments, BULKDATA_PayloadInSeperateFile was used to avoid the MIPs from being grouped under non streaming MIPs in TextureDerivedData.cpp. This however caused a lot of warnings with the MIP being wrongly classified as being on disk when its not (Loading non-streamed mips from an external bulk file).

This new flag is a variant of the streaming hack but with less log spam side effects every time an asset is loaded.

https://linear.app/bifrostai/issue/STA-2340/fix-this-ue-spam

Given the impact of this change, the following were tested:

Packaged + Editor

1. regular asset loads
2. load assets with MIP generation enabled
3. validate that streaming behavior is retained by changing pool sizes and seeing mip swaps
