### PR TITLE
fix: texture offlineprocessed flag to true

### DIFF
--- a/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
+++ b/Source/glTFRuntime/Private/glTFRuntimeParserMaterials.cpp
@@ -373,6 +373,8 @@ UTexture2D* FglTFRuntimeParser::BuildTexture(UObject* Outer, const TArray<FglTFR
 
 	Texture->LODBias = (ImagesConfig.LODBias >= 0 && ImagesConfig.LODBias < (Mips.Num() - 1)) ? ImagesConfig.LODBias : 0;
 	Texture->NeverStream = !ImagesConfig.bStreaming;
+	// glTFRuntime always supplies raw pixel data (never platform-tiled), regardless of streaming mode.
+	Texture->bNotOfflineProcessed = true;
 
 	if (ImagesConfig.bStreaming)
 	{
@@ -492,6 +494,8 @@ UVolumeTexture* FglTFRuntimeParser::BuildVolumeTexture(UObject* Outer, const TAr
 
 	Texture->LODBias = (ImagesConfig.LODBias >= 0 && ImagesConfig.LODBias < (Mips.Num() - 1)) ? ImagesConfig.LODBias : 0;
 	Texture->NeverStream = !ImagesConfig.bStreaming;
+	// glTFRuntime always supplies raw pixel data (never platform-tiled), regardless of streaming mode.
+	Texture->bNotOfflineProcessed = true;
 
 	if (ImagesConfig.bStreaming)
 	{

--- a/Source/glTFRuntime/Public/glTFRuntimeParser.h
+++ b/Source/glTFRuntime/Public/glTFRuntimeParser.h
@@ -1906,6 +1906,9 @@ public:
 
 #if ENGINE_MAJOR_VERSION >= 5
 	virtual bool WillProvideMipDataWithoutDisk() const override { return true; }
+#if ENGINE_MINOR_VERSION >= 7
+	virtual bool ShouldAllowPlatformTiling(const UTexture* Owner) const override { return false; }
+#endif
 #endif
 
 };


### PR DESCRIPTION
Be more strict on the texture state of gltf assets. All should be marked as unprocessed to be runtime managed. UE5.7 is stricter about this and will assert but this change is backwards compatible with 5.2.

https://linear.app/bifrostai/issue/STA-2602/gltf-asset-load-can-occasionally-fail-on-some-assets